### PR TITLE
[fix] replace account settings icon with cloud icon

### DIFF
--- a/src/pages/panel/workspace-settings/WorkspaceSettingsPage.tsx
+++ b/src/pages/panel/workspace-settings/WorkspaceSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
+import CloudIcon from '@mui/icons-material/Cloud'
 import PeopleIcon from '@mui/icons-material/People'
 import ReceiptIcon from '@mui/icons-material/Receipt'
 import { Button, Divider, Stack, Typography } from '@mui/material'
@@ -38,7 +38,7 @@ export default function WorkspaceSettingsPage() {
         <Trans>Other Workspace Settings</Trans>
       </Typography>
       <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems="start">
-        <Button variant="outlined" onClick={() => navigate('workspace-settings/accounts')} startIcon={<ManageAccountsIcon />}>
+        <Button variant="outlined" onClick={() => navigate('workspace-settings/accounts')} startIcon={<CloudIcon />}>
           <Trans>Accounts</Trans>
         </Button>
         <Button variant="outlined" onClick={() => navigate('workspace-settings/users')} startIcon={<PeopleIcon />}>

--- a/src/shared/layouts/panel-layout/menuList.tsx
+++ b/src/shared/layouts/panel-layout/menuList.tsx
@@ -1,9 +1,9 @@
 import { Trans } from '@lingui/macro'
 // eslint-disable-next-line no-restricted-imports
 import { SvgIconComponent } from '@mui/icons-material'
+import CloudIcon from '@mui/icons-material/Cloud'
 import DashboardIcon from '@mui/icons-material/Dashboard'
 import InventoryIcon from '@mui/icons-material/Inventory'
-import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
 import PeopleIcon from '@mui/icons-material/People'
 import ReceiptIcon from '@mui/icons-material/Receipt'
 import RoomPreferencesIcon from '@mui/icons-material/RoomPreferences'
@@ -51,7 +51,7 @@ export const bottomMenuList: MenuListItem[] = [
     Icon: RoomPreferencesIcon,
     children: [
       {
-        Icon: ManageAccountsIcon,
+        Icon: CloudIcon,
         name: <Trans>Accounts</Trans>,
         route: '/workspace-settings/accounts',
       },


### PR DESCRIPTION
# Description
replace account settings icon with cloud icon
![image](https://github.com/someengineering/fixfrontend/assets/2679112/294438d7-7d0c-49e2-9fa2-a46d400e4a4f)
