### PR TITLE
[feat] Allow matching JSON from query

### DIFF
--- a/src/shared/fixquery-parser/lexer.test.ts
+++ b/src/shared/fixquery-parser/lexer.test.ts
@@ -40,11 +40,12 @@ test(`number literals`, () => {
 })
 
 test(`literal literals`, () => {
+  assert.deepEqual(lex('Condition.IpAddress.`aws:SourceIp`[]'), ['Condition', '.', 'IpAddress', '.', '`aws:SourceIp`', '[', ']'])
   assert.deepEqual(lex('some-foo_bla-bar'), ['some-foo_bla-bar'])
   assert.deepEqual(lex('some_foo-bla-bar'), ['some_foo-bla-bar'])
   assert.deepEqual(lex('foo.bla[*].bar'), ['foo', '.', 'bla', '[', '*', ']', '.', 'bar'])
-  assert.deepEqual(lex('foo.`bla[*]`.bar'), ['foo', '.', '`bla[*]`.bar'])
-  assert.deepEqual(lex('foo.`bla\\`[*]`.bar'), ['foo', '.', '`bla\\`[*]`.bar'])
+  assert.deepEqual(lex('foo.`bla[*]`.bar'), ['foo', '.', '`bla[*]`', '.', 'bar'])
+  assert.deepEqual(lex('foo.`bla\\`[*]`.bar'), ['foo', '.', '`bla\\`[*]`', '.', 'bar'])
 })
 
 test(`double quoted literals`, () => {

--- a/src/shared/fixquery-parser/lexer.ts
+++ b/src/shared/fixquery-parser/lexer.ts
@@ -251,7 +251,7 @@ export class FixLexer implements Lexer<T> {
       if (input[index] === '`' && !last_is_escape) {
         const backtick = this.parse_until(input, index, '`')
         if (backtick) {
-          index = backtick
+          index = backtick - 1
         } else {
           return undefined
         }

--- a/src/shared/fixquery-parser/query.test.ts
+++ b/src/shared/fixquery-parser/query.test.ts
@@ -248,3 +248,17 @@ test('Find and change', () => {
     ],
   })
 })
+
+test('Indicate if a query can derive data from resource json', () => {
+  const queries: Array<[string, boolean]> = [
+    ['is(aws_lambda_function) with (empty, <-- is(aws_vpc))', false],
+    ['is(aws_lambda_function) and function_url_config.cors.allow_origins ~ "*"', true],
+    ['is(aws_lambda_function) and function_runtime in [python3.6, python2.7, dotnetcore2.1, ruby2.5]', true],
+    ['foo.bla.bar[*].{test in [python3.6, python2.7, dotnetcore2.1, ruby2.5] or rest==42}', true],
+    ['is(foo) --> is(bla)', false],
+    ['is(foo) {test: -->}', false],
+  ]
+  for (const [query, details] of queries) {
+    assert.strictEqual(Query.parse(query).provides_security_check_details(), details)
+  }
+})

--- a/src/shared/fixquery-parser/query.test.ts
+++ b/src/shared/fixquery-parser/query.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { Query } from './query.ts'
+import { JsonElement, JsonElementDraft, Path, Query } from './query.ts'
 
 test('Test query properties', () => {
   const query = Query.parse(
@@ -76,4 +76,175 @@ test('Update a query', () => {
 
   // original query should not be modified
   assert.strictEqual(query.toString(), q)
+})
+
+test('find paths', () => {
+  let jso: object = { a: 12, b: 21 }
+  let all_paths = [...Path.from_string('a').find_path(jso)]
+  assert.deepEqual(all_paths, [[Path.from('a'), 12]])
+
+  jso = { a: [{ b: [{ c: 21 }, { c: 22 }] }, { b: [{ c: 21 }, { c: 22 }] }] }
+  all_paths = [...Path.from_string('a[*].b[*].c').find_path(jso)]
+  assert.deepEqual(all_paths, [
+    [Path.from_string('a[0].b[0].c'), 21],
+    [Path.from_string('a[0].b[1].c'), 22],
+    [Path.from_string('a[1].b[0].c'), 21],
+    [Path.from_string('a[1].b[1].c'), 22],
+  ])
+})
+
+test('find matching path', () => {
+  // simple top level property
+  let js: object = { a: 1, prop: 42, b: 2 }
+  assert.deepEqual(Query.parse('prop == 42').find_matching(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop > 12').find_matching(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop >= 12').find_matching(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop < 45').find_matching(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop <= 45').find_matching(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop != 45').find_matching(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop =~ 4.').find_matching(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop ~ ".."').find_matching(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop > 43').find_matching(js), [])
+  assert.deepEqual(Query.parse('prop < 42').find_matching(js), [])
+  assert.deepEqual(js, { a: 1, prop: 42, b: 2 })
+
+  // nested property with array
+  const nested_array_predicate = Query.parse('foo[*].bla[*].bar[*].prop > 1')
+  js = {
+    a: 1,
+    foo: [
+      {
+        bla: [
+          { bar: [{ prop: 42, some: 1, other: 2 }] },
+          {
+            bar: [
+              { prop: 42, some: 1, other: 2 },
+              { prop: 42, some: 1, other: 2 },
+            ],
+          },
+        ],
+      },
+      { bla: [{ bar: [{ prop: 42, some: 1, other: 2 }] }] },
+    ],
+    b: 2,
+  }
+  const paths = nested_array_predicate.find_matching(js)
+  assert.deepEqual(paths, [
+    Path.from_string('foo[0].bla[0].bar[0].prop'),
+    Path.from_string('foo[0].bla[1].bar[0].prop'),
+    Path.from_string('foo[0].bla[1].bar[1].prop'),
+    Path.from_string('foo[1].bla[0].bar[0].prop'),
+  ])
+})
+test('Changing resource json: predicate', () => {
+  // simple top level property
+  let js: object = { a: 1, prop: 42, b: 2 }
+  assert.deepEqual(Query.parse('prop == 42').delete_matching(js), { a: 1, b: 2 })
+  assert.deepEqual(Query.parse('prop > 12').delete_matching(js), { a: 1, b: 2 })
+  assert.deepEqual(Query.parse('prop >= 12').delete_matching(js), { a: 1, b: 2 })
+  assert.deepEqual(Query.parse('prop < 45').delete_matching(js), { a: 1, b: 2 })
+  assert.deepEqual(Query.parse('prop <= 45').delete_matching(js), { a: 1, b: 2 })
+  assert.deepEqual(Query.parse('prop != 45').delete_matching(js), { a: 1, b: 2 })
+  assert.deepEqual(Query.parse('prop =~ 4.').delete_matching(js), { a: 1, b: 2 })
+  assert.deepEqual(Query.parse('prop ~ ".."').delete_matching(js), { a: 1, b: 2 })
+  assert.deepEqual(Query.parse('prop > 43').delete_matching(js), js)
+  assert.deepEqual(Query.parse('prop < 42').delete_matching(js), js)
+  assert.deepEqual(js, { a: 1, prop: 42, b: 2 })
+
+  // nested property
+  const nested_predicate = Query.parse('foo.bla.bar.prop == 42')
+  js = { a: 1, foo: { bla: { bar: { prop: 42, some: 1, other: 2 } } }, b: 2 }
+  let result: JsonElement = nested_predicate.delete_matching(js)
+  assert.deepEqual(result, { a: 1, b: 2, foo: { bla: { bar: { some: 1, other: 2 } } } })
+  assert.deepEqual(js, { a: 1, foo: { bla: { bar: { prop: 42, some: 1, other: 2 } } }, b: 2 })
+
+  // nested property with array
+  const nested_array_predicate = Query.parse('foo[*].bla[*].bar[*].prop > 1')
+  js = {
+    a: 1,
+    foo: [
+      {
+        bla: [
+          { bar: [{ prop: 42, some: 1, other: 2 }] },
+          {
+            bar: [
+              { prop: 42, some: 1, other: 2 },
+              { prop: 42, some: 1, other: 2 },
+            ],
+          },
+        ],
+      },
+      { bla: [{ bar: [{ prop: 42, some: 1, other: 2 }] }] },
+    ],
+    b: 2,
+  }
+  result = nested_array_predicate.delete_matching(js)
+  assert.deepEqual(result, {
+    a: 1,
+    foo: [
+      {
+        bla: [
+          { bar: [{ some: 1, other: 2 }] },
+          {
+            bar: [
+              { some: 1, other: 2 },
+              { some: 1, other: 2 },
+            ],
+          },
+        ],
+      },
+      { bla: [{ bar: [{ some: 1, other: 2 }] }] },
+    ],
+    b: 2,
+  })
+})
+
+test('Changing resource json: context term', () => {
+  // simple top level property
+  const js: object = { a: 1, b: 2, c: { d: { e: { f: [{ g: 1, h: 2 }] } } } }
+  assert.deepEqual(Query.parse('c.d.e.f[*].{g>0 and h<3}').delete_matching(js), { a: 1, b: 2, c: { d: { e: { f: [{}] } } } })
+  assert.deepEqual(Query.parse('c.d.e.f[*].{g>0 or h<3}').delete_matching(js), { a: 1, b: 2, c: { d: { e: { f: [{}] } } } })
+  assert.deepEqual(Query.parse('c.d.e.f[*].{g>0 or h>3}').delete_matching(js), { a: 1, b: 2, c: { d: { e: { f: [{ h: 2 }] } } } })
+  assert.deepEqual(Query.parse('c.d.e.f[*].{g<0 or (g>0 and h<3)}').delete_matching(js), { a: 1, b: 2, c: { d: { e: { f: [{}] } } } })
+})
+
+test('Find and change', () => {
+  const js = { a: 1, b: [1, 2, 3, 4], c: { d: { e: { f: [{ g: 1, h: 2 }] } } } }
+
+  let draft = new JsonElementDraft(js)
+  for (const m of draft.find_path(Path.from_string('c.d.e.f[*].g'))) m.set(42)
+  assert.deepEqual(draft.final_value, { a: 1, b: [1, 2, 3, 4], c: { d: { e: { f: [{ g: 42, h: 2 }] } } } })
+
+  draft = new JsonElementDraft(js)
+  for (const m of draft.find_path(Path.from_string('c.d.e.f[*].g'))) m.delete()
+  assert.deepEqual(draft.final_value, { a: 1, b: [1, 2, 3, 4], c: { d: { e: { f: [{ h: 2 }] } } } })
+
+  draft = new JsonElementDraft(js)
+  for (const m of draft.find_path(Path.from_string('c'))) m.delete()
+  for (const m of draft.find_path(Path.from_string('b[*]'))) m.delete()
+  assert.deepEqual(draft.final_value, { a: 1, b: [] })
+
+  draft = new JsonElementDraft(js)
+  for (const m of draft.find_path(Path.from_string('c'))) m.delete()
+  for (const m of draft.find_path(Path.from_string('b'))) m.delete()
+  assert.deepEqual(draft.final_value, { a: 1 })
+
+  draft = new JsonElementDraft(js)
+  for (const m of draft.find_path(Path.from_string('c'))) m.delete()
+  for (const m of draft.find_path(Path.from_string('b[*]'))) m.set(23)
+  assert.deepEqual(draft.final_value, { a: 1, b: [23, 23, 23, 23] })
+
+  draft = new JsonElementDraft(js)
+  for (const m of draft.find_path(Path.from_string('c'))) m.delete()
+  for (const m of draft.find_path(Path.from_string('b[1]'))) m.set(23)
+  assert.deepEqual(draft.final_value, { a: 1, b: [1, 23, 3, 4] })
+
+  draft = new JsonElementDraft({ t: [js, js] })
+  for (const m of draft.find_path(Path.from_string('t[*].c'))) m.delete()
+  assert.deepEqual(draft.final_value, {
+    t: [
+      { a: 1, b: [1, 2, 3, 4] },
+      { a: 1, b: [1, 2, 3, 4] },
+    ],
+  })
 })

--- a/src/shared/fixquery-parser/query.test.ts
+++ b/src/shared/fixquery-parser/query.test.ts
@@ -80,11 +80,11 @@ test('Update a query', () => {
 
 test('find paths', () => {
   let jso: object = { a: 12, b: 21 }
-  let all_paths = [...Path.from_string('a').find_path(jso)]
+  let all_paths = [...Path.from_string('a').find(jso)]
   assert.deepEqual(all_paths, [[Path.from('a'), 12]])
 
   jso = { a: [{ b: [{ c: 21 }, { c: 22 }] }, { b: [{ c: 21 }, { c: 22 }] }] }
-  all_paths = [...Path.from_string('a[*].b[*].c').find_path(jso)]
+  all_paths = [...Path.from_string('a[*].b[*].c').find(jso)]
   assert.deepEqual(all_paths, [
     [Path.from_string('a[0].b[0].c'), 21],
     [Path.from_string('a[0].b[1].c'), 22],
@@ -96,16 +96,16 @@ test('find paths', () => {
 test('find matching path', () => {
   // simple top level property
   let js: object = { a: 1, prop: 42, b: 2 }
-  assert.deepEqual(Query.parse('prop == 42').find_matching(js), [Path.from('prop')])
-  assert.deepEqual(Query.parse('prop > 12').find_matching(js), [Path.from('prop')])
-  assert.deepEqual(Query.parse('prop >= 12').find_matching(js), [Path.from('prop')])
-  assert.deepEqual(Query.parse('prop < 45').find_matching(js), [Path.from('prop')])
-  assert.deepEqual(Query.parse('prop <= 45').find_matching(js), [Path.from('prop')])
-  assert.deepEqual(Query.parse('prop != 45').find_matching(js), [Path.from('prop')])
-  assert.deepEqual(Query.parse('prop =~ 4.').find_matching(js), [Path.from('prop')])
-  assert.deepEqual(Query.parse('prop ~ ".."').find_matching(js), [Path.from('prop')])
-  assert.deepEqual(Query.parse('prop > 43').find_matching(js), [])
-  assert.deepEqual(Query.parse('prop < 42').find_matching(js), [])
+  assert.deepEqual(Query.parse('prop == 42').find_paths(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop > 12').find_paths(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop >= 12').find_paths(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop < 45').find_paths(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop <= 45').find_paths(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop != 45').find_paths(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop =~ 4.').find_paths(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop ~ ".."').find_paths(js), [Path.from('prop')])
+  assert.deepEqual(Query.parse('prop > 43').find_paths(js), [])
+  assert.deepEqual(Query.parse('prop < 42').find_paths(js), [])
   assert.deepEqual(js, { a: 1, prop: 42, b: 2 })
 
   // nested property with array
@@ -128,7 +128,7 @@ test('find matching path', () => {
     ],
     b: 2,
   }
-  const paths = nested_array_predicate.find_matching(js)
+  const paths = nested_array_predicate.find_paths(js)
   assert.deepEqual(paths, [
     Path.from_string('foo[0].bla[0].bar[0].prop'),
     Path.from_string('foo[0].bla[1].bar[0].prop'),
@@ -212,35 +212,35 @@ test('Find and change', () => {
   const js = { a: 1, b: [1, 2, 3, 4], c: { d: { e: { f: [{ g: 1, h: 2 }] } } } }
 
   let draft = new JsonElementDraft(js)
-  for (const m of draft.find_path(Path.from_string('c.d.e.f[*].g'))) m.set(42)
+  for (const m of draft.find(Path.from_string('c.d.e.f[*].g'))) m.set(42)
   assert.deepEqual(draft.final_value, { a: 1, b: [1, 2, 3, 4], c: { d: { e: { f: [{ g: 42, h: 2 }] } } } })
 
   draft = new JsonElementDraft(js)
-  for (const m of draft.find_path(Path.from_string('c.d.e.f[*].g'))) m.delete()
+  for (const m of draft.find(Path.from_string('c.d.e.f[*].g'))) m.delete()
   assert.deepEqual(draft.final_value, { a: 1, b: [1, 2, 3, 4], c: { d: { e: { f: [{ h: 2 }] } } } })
 
   draft = new JsonElementDraft(js)
-  for (const m of draft.find_path(Path.from_string('c'))) m.delete()
-  for (const m of draft.find_path(Path.from_string('b[*]'))) m.delete()
+  for (const m of draft.find(Path.from_string('c'))) m.delete()
+  for (const m of draft.find(Path.from_string('b[*]'))) m.delete()
   assert.deepEqual(draft.final_value, { a: 1, b: [] })
 
   draft = new JsonElementDraft(js)
-  for (const m of draft.find_path(Path.from_string('c'))) m.delete()
-  for (const m of draft.find_path(Path.from_string('b'))) m.delete()
+  for (const m of draft.find(Path.from_string('c'))) m.delete()
+  for (const m of draft.find(Path.from_string('b'))) m.delete()
   assert.deepEqual(draft.final_value, { a: 1 })
 
   draft = new JsonElementDraft(js)
-  for (const m of draft.find_path(Path.from_string('c'))) m.delete()
-  for (const m of draft.find_path(Path.from_string('b[*]'))) m.set(23)
+  for (const m of draft.find(Path.from_string('c'))) m.delete()
+  for (const m of draft.find(Path.from_string('b[*]'))) m.set(23)
   assert.deepEqual(draft.final_value, { a: 1, b: [23, 23, 23, 23] })
 
   draft = new JsonElementDraft(js)
-  for (const m of draft.find_path(Path.from_string('c'))) m.delete()
-  for (const m of draft.find_path(Path.from_string('b[1]'))) m.set(23)
+  for (const m of draft.find(Path.from_string('c'))) m.delete()
+  for (const m of draft.find(Path.from_string('b[1]'))) m.set(23)
   assert.deepEqual(draft.final_value, { a: 1, b: [1, 23, 3, 4] })
 
   draft = new JsonElementDraft({ t: [js, js] })
-  for (const m of draft.find_path(Path.from_string('t[*].c'))) m.delete()
+  for (const m of draft.find(Path.from_string('t[*].c'))) m.delete()
   assert.deepEqual(draft.final_value, {
     t: [
       { a: 1, b: [1, 2, 3, 4] },


### PR DESCRIPTION
# Description

```ts
  // assume this query is a security check
  const query_str = 'is(aws_lambda_function) and function_url_config.cors.allow_origins ~ "*"'
  // assume this is the reported section of the resource json
  const resource_json = { ... }
  // parse the query
  const query = Query.parse(query_str)
  // check if the query can derive data from the resource json
  if (query.provides_security_check_details()) {
    // find the paths in the resource json that match the query
    const paths:Path[] = query.find_paths(resource_json)
  }
```

<!-- Please describe the changes included in this PR here. -->

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
