### PR TITLE
[fix] Fix resources text in failed-checks

### DIFF
--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -763,10 +763,6 @@ msgstr "Free"
 msgid "Get your top 5 recommendations to improve your security once the first scan is complete, usually within 10 minutes."
 msgstr "Erhalten Sie Ihre fünf wichtigsten Empfehlungen zur Verbesserung Ihrer Sicherheit, sobald der erste Scan abgeschlossen ist, normalerweise innerhalb von 10 Minuten."
 
-#: src/pages/panel/shared/failed-checks/FailedChecks.tsx:129
-msgid "Go to resources"
-msgstr "Gehen Sie zu Ressourcen"
-
 #: src/shared/defined-messages/getMessage.ts:8
 msgid "High"
 msgstr "Hoch"
@@ -1314,6 +1310,10 @@ msgstr "E-Mail-Benachrichtigungen einrichten"
 #: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:205
 msgid "Severity"
 msgstr "Schwere"
+
+#: src/pages/panel/shared/failed-checks/FailedChecks.tsx:129
+msgid "Show resources"
+msgstr "Ressourcen anzeigen"
 
 #: src/pages/auth/register/RegisterPage.tsx:125
 msgid "Sign up"

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -763,10 +763,6 @@ msgstr "Free"
 msgid "Get your top 5 recommendations to improve your security once the first scan is complete, usually within 10 minutes."
 msgstr "Get your top 5 recommendations to improve your security once the first scan is complete, usually within 10 minutes."
 
-#: src/pages/panel/shared/failed-checks/FailedChecks.tsx:129
-msgid "Go to resources"
-msgstr "Go to resources"
-
 #: src/shared/defined-messages/getMessage.ts:8
 msgid "High"
 msgstr "High"
@@ -1314,6 +1310,10 @@ msgstr "Setting Up Email Notifications"
 #: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:205
 msgid "Severity"
 msgstr "Severity"
+
+#: src/pages/panel/shared/failed-checks/FailedChecks.tsx:129
+msgid "Show resources"
+msgstr "Show resources"
 
 #: src/pages/auth/register/RegisterPage.tsx:125
 msgid "Sign up"

--- a/src/pages/panel/shared/failed-checks/FailedChecks.tsx
+++ b/src/pages/panel/shared/failed-checks/FailedChecks.tsx
@@ -126,7 +126,7 @@ export const FailedChecks = ({ failedCheck, navigate, smallText, withResources, 
           <Stack spacing={1} direction="row">
             {navigate && (
               <Button onClick={() => navigate(createInventorySearchTo(query))} variant="outlined">
-                <Trans>Go to resources</Trans>
+                <Trans>Show resources</Trans>
               </Button>
             )}
             <Button href={failedCheck.remediation.url} target="_blank" rel="noopener noreferrer" endIcon={<OpenInNewIcon />}>


### PR DESCRIPTION
# Description
Fix resources text in failed-checks
![image](https://github.com/someengineering/fixfrontend/assets/2679112/8075895c-01ce-4a35-81d3-1d82d7cbb384)

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
