### PR TITLE
fix(inventory-page): not showing resource detail when there's no q at all

### DIFF
--- a/src/pages/panel/inventory/InventoryAdvanceSearch.tsx
+++ b/src/pages/panel/inventory/InventoryAdvanceSearch.tsx
@@ -46,7 +46,7 @@ export const InventoryAdvanceSearch = ({ value: searchCrit, onChange, hasError, 
         try {
           updateQuery(value)
         } catch (e) {
-          console.error(e, value)
+          console.info(e, value)
         }
         timeoutRef.current = undefined
       }, panelUI.inputChangeDebounce)
@@ -81,7 +81,7 @@ export const InventoryAdvanceSearch = ({ value: searchCrit, onChange, hasError, 
     try {
       updateQuery(!searchCrit ? '' : searchCrit)
     } catch (e) {
-      console.error(e, !searchCrit ? '' : searchCrit)
+      console.info(e, !searchCrit ? '' : searchCrit)
     }
   }, [searchCrit, updateQuery])
 

--- a/src/pages/panel/inventory/InventoryPage.tsx
+++ b/src/pages/panel/inventory/InventoryPage.tsx
@@ -24,7 +24,7 @@ export default function InventoryPage() {
 
   const setSearchCrit = useCallback(
     (crit?: string) => {
-      if (crit === undefined) {
+      if (!crit || crit === 'all') {
         return
       }
       const searchValues = getLocationSearchValues()


### PR DESCRIPTION
# Description
not showing resource detail when there's no q at all

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
