### PR TITLE
[fix]: make the property filter autocomplete box multiline

### DIFF
--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -968,7 +968,7 @@ msgstr "Integrationsberatung für Ihre spezifische Cloud-Umgebung per Videoanruf
 msgid "Integration Key"
 msgstr "Integrationsschlüssel"
 
-#: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx:343
+#: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx:333
 #: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowStringValue.tsx:244
 msgid "Invalid Value"
 msgstr "Ungültiger Wert"
@@ -1348,7 +1348,7 @@ msgstr "Profil"
 msgid "Properties"
 msgstr ""
 
-#: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx:364
+#: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx:355
 msgid "Property"
 msgstr "Eigentum"
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -968,7 +968,7 @@ msgstr "Integration advice for your specific cloud environment via video call"
 msgid "Integration Key"
 msgstr "Integration Key"
 
-#: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx:343
+#: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx:333
 #: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowStringValue.tsx:244
 msgid "Invalid Value"
 msgstr "Invalid Value"
@@ -1348,7 +1348,7 @@ msgstr "Profile"
 msgid "Properties"
 msgstr "Properties"
 
-#: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx:364
+#: src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx:355
 msgid "Property"
 msgstr "Property"
 

--- a/src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx
+++ b/src/pages/panel/inventory/inventory-form/InventoryFormFilterRowProperty.tsx
@@ -1,15 +1,6 @@
 import { Trans, t } from '@lingui/macro'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import {
-  Autocomplete,
-  AutocompleteRenderOptionState,
-  CircularProgress,
-  ListItemButton,
-  Stack,
-  TextField,
-  Tooltip,
-  Typography,
-} from '@mui/material'
+import { Autocomplete, AutocompleteRenderOptionState, CircularProgress, ListItemButton, Stack, TextField, Typography } from '@mui/material'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { useDebounce } from '@uidotdev/usehooks'
 import { AxiosError } from 'axios'
@@ -189,7 +180,7 @@ export const InventoryFormFilterRowProperty = ({
     return true
   }
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
+    const value = e.target.value.replace(/\u200B/g, '')
     if (!isDictionary) {
       setFqn('object')
     }
@@ -336,35 +327,34 @@ export const InventoryFormFilterRowProperty = ({
       loading={autoCompleteIsLoading}
       ListboxProps={{ onScroll: handleScroll }}
       renderInput={(params) => (
-        <Tooltip title={autoCompleteInputValue}>
-          <TextField
-            {...params}
-            error={hasError}
-            helperText={hasError ? t`Invalid Value` : undefined}
-            focused={hasFocus && !!fqn}
-            autoFocus
-            InputProps={{
-              ...params.InputProps,
-              startAdornment: defaultForcedValue ? <Typography variant="caption">{defaultForcedValue}</Typography> : undefined,
-              endAdornment: (
-                <>
-                  {isLoading || isFetchingNextPage ? <CircularProgress color="inherit" size={20} /> : null}
-                  {params.InputProps.endAdornment}
-                </>
-              ),
-            }}
-            inputProps={{
-              ...params.inputProps,
-              autoFocus: true,
-              value: autoCompleteInputValue,
-              onKeyDown: handleInputKeyDown,
-              onFocus: () => setHasFocus(true),
-              onBlur: () => setHasFocus(false),
-            }}
-            label={<Trans>Property</Trans>}
-            onChange={handleInputChange}
-          />
-        </Tooltip>
+        <TextField
+          {...params}
+          error={hasError}
+          helperText={hasError ? t`Invalid Value` : undefined}
+          focused={hasFocus && !!fqn}
+          autoFocus
+          InputProps={{
+            ...params.InputProps,
+            startAdornment: defaultForcedValue ? <Typography variant="caption">{defaultForcedValue}</Typography> : undefined,
+            endAdornment: (
+              <>
+                {isLoading || isFetchingNextPage ? <CircularProgress color="inherit" size={20} /> : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+          multiline
+          inputProps={{
+            ...params.inputProps,
+            autoFocus: true,
+            value: autoCompleteInputValue.replace(/([_.])(?=\S)/g, '$1\u200B'),
+            onKeyDown: handleInputKeyDown,
+            onFocus: () => setHasFocus(true),
+            onBlur: () => setHasFocus(false),
+          }}
+          label={<Trans>Property</Trans>}
+          onChange={handleInputChange}
+        />
       )}
     />
   )


### PR DESCRIPTION
# Description
Issue No: 630
Make the property filter autocomplete box multiline and remove the tooltip
![image](https://github.com/someengineering/fixfrontend/assets/2679112/195f4745-6c31-4b26-a5f3-6d0ea3fa22e2)

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
