### PR TITLE
[fix] re-order payment methods make aws marketplace to be the first

### DIFF
--- a/src/pages/panel/workspace-settings-billing/utils/paymentMethods.ts
+++ b/src/pages/panel/workspace-settings-billing/utils/paymentMethods.ts
@@ -1,3 +1,3 @@
 import { PaymentMethods } from 'src/shared/types/server-shared'
 
-export const paymentMethods: PaymentMethods[] = ['stripe', 'aws_marketplace']
+export const paymentMethods: PaymentMethods[] = ['aws_marketplace', 'stripe']


### PR DESCRIPTION
# Description
re-order payment methods make aws marketplace to be the first

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
