### PR TITLE
[fix] fix benchmark item showing wrong severity

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-# yarn lint-staged
+yarn lint-staged

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -470,7 +470,7 @@ msgstr "Da die Daten über {0} liegen, werden nur die ersten {1} Elemente herunt
 msgid "below"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:101
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:102
 #: src/pages/panel/user-settings/UserSettingsNotification.tsx:46
 #: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:160
 msgid "Benchmark"
@@ -1214,7 +1214,7 @@ msgstr "Ignoriert"
 msgid "Improved"
 msgstr "Verbessert"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:105
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:106
 msgid "in account"
 msgstr ""
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -470,7 +470,7 @@ msgstr "Because the data is over {0} Only first {1} items will be downloaded"
 msgid "below"
 msgstr "below"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:101
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:102
 #: src/pages/panel/user-settings/UserSettingsNotification.tsx:46
 #: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:160
 msgid "Benchmark"
@@ -1214,7 +1214,7 @@ msgstr "Ignored"
 msgid "Improved"
 msgstr "Improved"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:105
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:106
 msgid "in account"
 msgstr "in account"
 

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx
@@ -63,8 +63,9 @@ export const BenchmarkDetailTree = () => {
           }
           from.numberOfResourceFailing += to.numberOfResourceFailing
           if (
-            !from.severity ||
-            (to.severity && to.numberOfResourceFailing && sortedSeverities.indexOf(to.severity) < sortedSeverities.indexOf(from.severity))
+            to.severity &&
+            to.numberOfResourceFailing &&
+            (!from.severity || sortedSeverities.indexOf(to.severity) < sortedSeverities.indexOf(from.severity))
           ) {
             from.severity = to.severity
           }


### PR DESCRIPTION
# Description
#### Issue No: 740
fix benchmark item showing wrong severity

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
