### PR TITLE
[fix] add manual info section into benchmark detail

### DIFF
--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -123,7 +123,7 @@ msgstr "/ Monat"
 msgid "© 2024 Some Engineering Inc. All rights reserved."
 msgstr "© 2024 Some Engineering Inc. Alle Rechte vorbehalten."
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:63
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:65
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:86
 msgid "<0>{0} checks failing</0> out of {1}"
 msgstr ""
@@ -229,7 +229,7 @@ msgstr ""
 msgid "Access to your account is broken"
 msgstr "Der Zugriff auf Ihr Konto ist unterbrochen"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:205
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:195
 #: src/pages/panel/inventory/inventory-form/InventoryFormAccount.tsx:60
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:239
 msgid "Account"
@@ -332,7 +332,7 @@ msgstr ""
 msgid "Advanced search query"
 msgstr "Erweiterte Suchabfrage"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:146
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:136
 msgid "Affected resources"
 msgstr ""
 
@@ -353,8 +353,8 @@ msgstr "Benachrichtigungseinstellungen"
 msgid "All checks have been disabled for this resource"
 msgstr "Für diese Ressource wurden alle Prüfungen deaktiviert"
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:164
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:242
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:177
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:232
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:187
 msgid "All resources passed the check"
 msgstr ""
@@ -478,7 +478,7 @@ msgstr "Da die Daten über {0} liegen, werden nur die ersten {1} Elemente herunt
 msgid "below"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:102
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:106
 #: src/pages/panel/user-settings/UserSettingsNotification.tsx:46
 #: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:160
 msgid "Benchmark"
@@ -570,7 +570,7 @@ msgstr "Änderungen"
 msgid "Changes in the past 7 days"
 msgstr "Änderungen in den letzten 7 Tagen"
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:100
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:102
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:123
 msgid "Check Name"
 msgstr ""
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Close"
 msgstr "Schließen"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:175
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:165
 #: src/pages/panel/inventory/inventory-form/InventoryFormCloudValues.tsx:57
 #: src/pages/panel/inventory/inventory-form/InventoryFormMore.tsx:96
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:235
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Created Time"
 msgstr "Erstellte Zeit"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:211
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:201
 msgid "Creation Date"
 msgstr ""
 
@@ -1045,7 +1045,7 @@ msgstr "Fehlgeschlagene Benchmarks"
 msgid "Failing Check Timeline"
 msgstr "Fehler bei der Überprüfung des Zeitplans"
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:94
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:96
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:117
 msgid "Failing Resources"
 msgstr ""
@@ -1165,19 +1165,16 @@ msgstr "Startseite"
 msgid "Hourly"
 msgstr "Stündliche"
 
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:116
 #: src/pages/panel/shared/failed-checks/FailedChecks.tsx:111
 msgid "How to fix"
 msgstr "Wie repariert man"
-
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:117
-msgid "How to fix{0}"
-msgstr ""
 
 #: src/pages/panel/workspace-settings-accounts-setup-cloud-gcp/getInstructions.tsx:45
 msgid "IAM"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:181
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:171
 msgid "Id"
 msgstr ""
 
@@ -1238,7 +1235,7 @@ msgstr "Ignoriert"
 msgid "Improved"
 msgstr "Verbessert"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:106
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:110
 msgid "in account"
 msgstr ""
 
@@ -1270,7 +1267,7 @@ msgstr "Info"
 msgid "Info: Changes to your product tier will become active immediately and be applied for the current billing cycle. {0}<0/>Your next billing cycle starts: {1} UTC"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:86
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:85
 msgid "Inspect Detection Search in Inventory"
 msgstr ""
 
@@ -1321,7 +1318,7 @@ msgstr "Lädt ein"
 msgid "kind"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:199
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:189
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:231
 #: src/shared/charts/NetworkDiagram.tsx:406
 msgid "Kind"
@@ -1335,7 +1332,7 @@ msgstr "Arten"
 msgid "Last login"
 msgstr "Letzte Anmeldung"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:106
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:105
 msgid "Learn more about the associated risk"
 msgstr ""
 
@@ -1381,8 +1378,8 @@ msgstr ""
 msgid "Manage Card Details"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:121
-msgid "manual"
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx:34
+msgid "Manual"
 msgstr ""
 
 #: src/pages/panel/workspace-settings-billing/ProductTierComp.tsx:53
@@ -1427,7 +1424,7 @@ msgstr "Am meisten verbesserte Ressourcen"
 msgid "Most Non-Compliant Accounts"
 msgstr "Die meisten nicht konformen Konten"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:187
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:177
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:233
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountRow.tsx:478
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountsTableItem.tsx:59
@@ -1737,7 +1734,7 @@ msgstr ""
 msgid "Plus"
 msgstr "Plus"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:138
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:128
 msgid "Practical remediation guidance"
 msgstr ""
 
@@ -1826,7 +1823,7 @@ msgstr "Wiederherstellungscodes"
 msgid "Regenerate"
 msgstr "Regenerieren"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:193
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:183
 #: src/pages/panel/inventory/inventory-form/InventoryFormMore.tsx:97
 #: src/pages/panel/inventory/inventory-form/InventoryFormRegionValues.tsx:54
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:240
@@ -2022,7 +2019,7 @@ msgstr ""
 msgid "Severities"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:79
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:81
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:102
 #: src/pages/panel/inventory/inventory-form/InventoryFormSeverity.tsx:50
 #: src/pages/panel/inventory/inventory-form/utils/getAutoCompleteFromKey.tsx:156
@@ -2156,7 +2153,7 @@ msgstr "Diese Email-Adresse ist bereits registriert. Wenn dies Ihre E-Mail-Adres
 msgid "This project is currently in a degraded state.<0/>Fix was unable to gather data from this project.<1/><2/>To resume security scans, please ensure that the service account you configured is set up correctly.<3/>You may also recreate and upload the service account definition."
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:250
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:166
 msgid "This section does not contain any controls that can be automated.<0/>Manual checks or processes are required for compliance."
 msgstr ""
 
@@ -2335,8 +2332,8 @@ msgstr "Wöchentlicher E-Mail-Bericht"
 msgid "Weekly Report"
 msgstr "Wöchentlicher Report"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:103
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:111
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:102
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:110
 msgid "Why does it matter"
 msgstr ""
 

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -229,7 +229,7 @@ msgstr ""
 msgid "Access to your account is broken"
 msgstr "Der Zugriff auf Ihr Konto ist unterbrochen"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:195
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:205
 #: src/pages/panel/inventory/inventory-form/InventoryFormAccount.tsx:60
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:239
 msgid "Account"
@@ -332,7 +332,7 @@ msgstr ""
 msgid "Advanced search query"
 msgstr "Erweiterte Suchabfrage"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:136
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:146
 msgid "Affected resources"
 msgstr ""
 
@@ -354,7 +354,7 @@ msgid "All checks have been disabled for this resource"
 msgstr "Für diese Ressource wurden alle Prüfungen deaktiviert"
 
 #: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:164
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:233
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:242
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:187
 msgid "All resources passed the check"
 msgstr ""
@@ -636,7 +636,7 @@ msgstr ""
 msgid "Close"
 msgstr "Schließen"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:165
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:175
 #: src/pages/panel/inventory/inventory-form/InventoryFormCloudValues.tsx:57
 #: src/pages/panel/inventory/inventory-form/InventoryFormMore.tsx:96
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:235
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Created Time"
 msgstr "Erstellte Zeit"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:201
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:211
 msgid "Creation Date"
 msgstr ""
 
@@ -1165,16 +1165,19 @@ msgstr "Startseite"
 msgid "Hourly"
 msgstr "Stündliche"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:116
 #: src/pages/panel/shared/failed-checks/FailedChecks.tsx:111
 msgid "How to fix"
 msgstr "Wie repariert man"
+
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:117
+msgid "How to fix{0}"
+msgstr ""
 
 #: src/pages/panel/workspace-settings-accounts-setup-cloud-gcp/getInstructions.tsx:45
 msgid "IAM"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:171
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:181
 msgid "Id"
 msgstr ""
 
@@ -1267,7 +1270,7 @@ msgstr "Info"
 msgid "Info: Changes to your product tier will become active immediately and be applied for the current billing cycle. {0}<0/>Your next billing cycle starts: {1} UTC"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:85
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:86
 msgid "Inspect Detection Search in Inventory"
 msgstr ""
 
@@ -1318,7 +1321,7 @@ msgstr "Lädt ein"
 msgid "kind"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:189
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:199
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:231
 #: src/shared/charts/NetworkDiagram.tsx:406
 msgid "Kind"
@@ -1332,7 +1335,7 @@ msgstr "Arten"
 msgid "Last login"
 msgstr "Letzte Anmeldung"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:105
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:106
 msgid "Learn more about the associated risk"
 msgstr ""
 
@@ -1378,6 +1381,10 @@ msgstr ""
 msgid "Manage Card Details"
 msgstr ""
 
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:121
+msgid "manual"
+msgstr ""
+
 #: src/pages/panel/workspace-settings-billing/ProductTierComp.tsx:53
 msgid "maximum of {0} cloud accounts"
 msgstr "maximal {0} Cloud-Konten"
@@ -1420,7 +1427,7 @@ msgstr "Am meisten verbesserte Ressourcen"
 msgid "Most Non-Compliant Accounts"
 msgstr "Die meisten nicht konformen Konten"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:177
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:187
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:233
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountRow.tsx:478
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountsTableItem.tsx:59
@@ -1730,7 +1737,7 @@ msgstr ""
 msgid "Plus"
 msgstr "Plus"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:128
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:138
 msgid "Practical remediation guidance"
 msgstr ""
 
@@ -1819,7 +1826,7 @@ msgstr "Wiederherstellungscodes"
 msgid "Regenerate"
 msgstr "Regenerieren"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:183
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:193
 #: src/pages/panel/inventory/inventory-form/InventoryFormMore.tsx:97
 #: src/pages/panel/inventory/inventory-form/InventoryFormRegionValues.tsx:54
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:240
@@ -2149,6 +2156,10 @@ msgstr "Diese Email-Adresse ist bereits registriert. Wenn dies Ihre E-Mail-Adres
 msgid "This project is currently in a degraded state.<0/>Fix was unable to gather data from this project.<1/><2/>To resume security scans, please ensure that the service account you configured is set up correctly.<3/>You may also recreate and upload the service account definition."
 msgstr ""
 
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:250
+msgid "This section does not contain any controls that can be automated.<0/>Manual checks or processes are required for compliance."
+msgstr ""
+
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountRow.tsx:416
 msgid "This subscription is currently in a degraded state.<0/>Fix was unable to gather data from this subscription.<1/><2/>To resume security scans, please ensure that the application permissions are set up correctly.<3/>You may also recreate and redefine the access credentials."
 msgstr ""
@@ -2324,8 +2335,8 @@ msgstr "Wöchentlicher E-Mail-Bericht"
 msgid "Weekly Report"
 msgstr "Wöchentlicher Report"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:102
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:110
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:103
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:111
 msgid "Why does it matter"
 msgstr ""
 

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -1378,7 +1378,7 @@ msgstr ""
 msgid "Manage Card Details"
 msgstr ""
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx:34
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx:48
 msgid "Manual"
 msgstr ""
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -1378,7 +1378,7 @@ msgstr "Manage AWS Market place payment method"
 msgid "Manage Card Details"
 msgstr "Manage Card Details"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx:34
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx:48
 msgid "Manual"
 msgstr "Manual"
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -123,7 +123,7 @@ msgstr "/ month"
 msgid "© 2024 Some Engineering Inc. All rights reserved."
 msgstr "© 2024 Some Engineering Inc. All rights reserved."
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:63
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:65
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:86
 msgid "<0>{0} checks failing</0> out of {1}"
 msgstr "<0>{0} checks failing</0> out of {1}"
@@ -229,7 +229,7 @@ msgstr "Access Control (IAM)"
 msgid "Access to your account is broken"
 msgstr "Access to your account is broken"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:205
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:195
 #: src/pages/panel/inventory/inventory-form/InventoryFormAccount.tsx:60
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:239
 msgid "Account"
@@ -332,7 +332,7 @@ msgstr "Advanced"
 msgid "Advanced search query"
 msgstr "Advanced search query"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:146
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:136
 msgid "Affected resources"
 msgstr "Affected resources"
 
@@ -353,8 +353,8 @@ msgstr "Alerting Settings"
 msgid "All checks have been disabled for this resource"
 msgstr "All checks have been disabled for this resource"
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:164
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:242
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:177
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:232
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:187
 msgid "All resources passed the check"
 msgstr "All resources passed the check"
@@ -478,7 +478,7 @@ msgstr "Because the data is over {0} Only first {1} items will be downloaded"
 msgid "below"
 msgstr "below"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:102
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:106
 #: src/pages/panel/user-settings/UserSettingsNotification.tsx:46
 #: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:160
 msgid "Benchmark"
@@ -570,7 +570,7 @@ msgstr "Changes"
 msgid "Changes in the past 7 days"
 msgstr "Changes in the past 7 days"
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:100
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:102
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:123
 msgid "Check Name"
 msgstr "Check Name"
@@ -636,7 +636,7 @@ msgstr "Client secret"
 msgid "Close"
 msgstr "Close"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:175
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:165
 #: src/pages/panel/inventory/inventory-form/InventoryFormCloudValues.tsx:57
 #: src/pages/panel/inventory/inventory-form/InventoryFormMore.tsx:96
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:235
@@ -765,7 +765,7 @@ msgstr "Create Service Account"
 msgid "Created Time"
 msgstr "Created Time"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:211
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:201
 msgid "Creation Date"
 msgstr "Creation Date"
 
@@ -1045,7 +1045,7 @@ msgstr "Failing benchmarks"
 msgid "Failing Check Timeline"
 msgstr "Failing Check Timeline"
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:94
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:96
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:117
 msgid "Failing Resources"
 msgstr "Failing Resources"
@@ -1165,19 +1165,16 @@ msgstr "Homepage"
 msgid "Hourly"
 msgstr "Hourly"
 
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:116
 #: src/pages/panel/shared/failed-checks/FailedChecks.tsx:111
 msgid "How to fix"
 msgstr "How to fix"
-
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:117
-msgid "How to fix{0}"
-msgstr "How to fix{0}"
 
 #: src/pages/panel/workspace-settings-accounts-setup-cloud-gcp/getInstructions.tsx:45
 msgid "IAM"
 msgstr "IAM"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:181
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:171
 msgid "Id"
 msgstr "Id"
 
@@ -1238,7 +1235,7 @@ msgstr "Ignored"
 msgid "Improved"
 msgstr "Improved"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:106
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx:110
 msgid "in account"
 msgstr "in account"
 
@@ -1270,7 +1267,7 @@ msgstr "Info"
 msgid "Info: Changes to your product tier will become active immediately and be applied for the current billing cycle. {0}<0/>Your next billing cycle starts: {1} UTC"
 msgstr "Info: Changes to your product tier will become active immediately and be applied for the current billing cycle. {0}<0/>Your next billing cycle starts: {1} UTC"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:86
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:85
 msgid "Inspect Detection Search in Inventory"
 msgstr "Inspect Detection Search in Inventory"
 
@@ -1321,7 +1318,7 @@ msgstr "Invites"
 msgid "kind"
 msgstr "kind"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:199
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:189
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:231
 #: src/shared/charts/NetworkDiagram.tsx:406
 msgid "Kind"
@@ -1335,7 +1332,7 @@ msgstr "Kinds"
 msgid "Last login"
 msgstr "Last login"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:106
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:105
 msgid "Learn more about the associated risk"
 msgstr "Learn more about the associated risk"
 
@@ -1381,9 +1378,9 @@ msgstr "Manage AWS Market place payment method"
 msgid "Manage Card Details"
 msgstr "Manage Card Details"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:121
-msgid "manual"
-msgstr "manual"
+#: src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx:34
+msgid "Manual"
+msgstr "Manual"
 
 #: src/pages/panel/workspace-settings-billing/ProductTierComp.tsx:53
 msgid "maximum of {0} cloud accounts"
@@ -1427,7 +1424,7 @@ msgstr "Most Improved Resources"
 msgid "Most Non-Compliant Accounts"
 msgstr "Most Non-Compliant Accounts"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:187
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:177
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:233
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountRow.tsx:478
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountsTableItem.tsx:59
@@ -1737,7 +1734,7 @@ msgstr "Please select the workspace where you would like to activate this subscr
 msgid "Plus"
 msgstr "Plus"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:138
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:128
 msgid "Practical remediation guidance"
 msgstr "Practical remediation guidance"
 
@@ -1826,7 +1823,7 @@ msgstr "Recovery codes"
 msgid "Regenerate"
 msgstr "Regenerate"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:193
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:183
 #: src/pages/panel/inventory/inventory-form/InventoryFormMore.tsx:97
 #: src/pages/panel/inventory/inventory-form/InventoryFormRegionValues.tsx:54
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:240
@@ -2022,7 +2019,7 @@ msgstr "Setup cloud"
 msgid "Severities"
 msgstr "Severities"
 
-#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:79
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:81
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:102
 #: src/pages/panel/inventory/inventory-form/InventoryFormSeverity.tsx:50
 #: src/pages/panel/inventory/inventory-form/utils/getAutoCompleteFromKey.tsx:156
@@ -2156,7 +2153,7 @@ msgstr "This email address is already registered. If this is your email, please 
 msgid "This project is currently in a degraded state.<0/>Fix was unable to gather data from this project.<1/><2/>To resume security scans, please ensure that the service account you configured is set up correctly.<3/>You may also recreate and upload the service account definition."
 msgstr "This project is currently in a degraded state.<0/>Fix was unable to gather data from this project.<1/><2/>To resume security scans, please ensure that the service account you configured is set up correctly.<3/>You may also recreate and upload the service account definition."
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:250
+#: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:166
 msgid "This section does not contain any controls that can be automated.<0/>Manual checks or processes are required for compliance."
 msgstr "This section does not contain any controls that can be automated.<0/>Manual checks or processes are required for compliance."
 
@@ -2335,8 +2332,8 @@ msgstr "Weekly email report"
 msgid "Weekly Report"
 msgstr "Weekly Report"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:103
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:111
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:102
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:110
 msgid "Why does it matter"
 msgstr "Why does it matter"
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -229,7 +229,7 @@ msgstr "Access Control (IAM)"
 msgid "Access to your account is broken"
 msgstr "Access to your account is broken"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:195
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:205
 #: src/pages/panel/inventory/inventory-form/InventoryFormAccount.tsx:60
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:239
 msgid "Account"
@@ -332,7 +332,7 @@ msgstr "Advanced"
 msgid "Advanced search query"
 msgstr "Advanced search query"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:136
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:146
 msgid "Affected resources"
 msgstr "Affected resources"
 
@@ -354,7 +354,7 @@ msgid "All checks have been disabled for this resource"
 msgstr "All checks have been disabled for this resource"
 
 #: src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx:164
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:233
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:242
 #: src/pages/panel/benchmark-detail/BenchmarkDetailView.tsx:187
 msgid "All resources passed the check"
 msgstr "All resources passed the check"
@@ -636,7 +636,7 @@ msgstr "Client secret"
 msgid "Close"
 msgstr "Close"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:165
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:175
 #: src/pages/panel/inventory/inventory-form/InventoryFormCloudValues.tsx:57
 #: src/pages/panel/inventory/inventory-form/InventoryFormMore.tsx:96
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:235
@@ -765,7 +765,7 @@ msgstr "Create Service Account"
 msgid "Created Time"
 msgstr "Created Time"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:201
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:211
 msgid "Creation Date"
 msgstr "Creation Date"
 
@@ -1165,16 +1165,19 @@ msgstr "Homepage"
 msgid "Hourly"
 msgstr "Hourly"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:116
 #: src/pages/panel/shared/failed-checks/FailedChecks.tsx:111
 msgid "How to fix"
 msgstr "How to fix"
+
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:117
+msgid "How to fix{0}"
+msgstr "How to fix{0}"
 
 #: src/pages/panel/workspace-settings-accounts-setup-cloud-gcp/getInstructions.tsx:45
 msgid "IAM"
 msgstr "IAM"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:171
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:181
 msgid "Id"
 msgstr "Id"
 
@@ -1267,7 +1270,7 @@ msgstr "Info"
 msgid "Info: Changes to your product tier will become active immediately and be applied for the current billing cycle. {0}<0/>Your next billing cycle starts: {1} UTC"
 msgstr "Info: Changes to your product tier will become active immediately and be applied for the current billing cycle. {0}<0/>Your next billing cycle starts: {1} UTC"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:85
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:86
 msgid "Inspect Detection Search in Inventory"
 msgstr "Inspect Detection Search in Inventory"
 
@@ -1318,7 +1321,7 @@ msgstr "Invites"
 msgid "kind"
 msgstr "kind"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:189
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:199
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:231
 #: src/shared/charts/NetworkDiagram.tsx:406
 msgid "Kind"
@@ -1332,7 +1335,7 @@ msgstr "Kinds"
 msgid "Last login"
 msgstr "Last login"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:105
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:106
 msgid "Learn more about the associated risk"
 msgstr "Learn more about the associated risk"
 
@@ -1378,6 +1381,10 @@ msgstr "Manage AWS Market place payment method"
 msgid "Manage Card Details"
 msgstr "Manage Card Details"
 
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:121
+msgid "manual"
+msgstr "manual"
+
 #: src/pages/panel/workspace-settings-billing/ProductTierComp.tsx:53
 msgid "maximum of {0} cloud accounts"
 msgstr "maximum of {0} cloud accounts"
@@ -1420,7 +1427,7 @@ msgstr "Most Improved Resources"
 msgid "Most Non-Compliant Accounts"
 msgstr "Most Non-Compliant Accounts"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:177
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:187
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:233
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountRow.tsx:478
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountsTableItem.tsx:59
@@ -1730,7 +1737,7 @@ msgstr "Please select the workspace where you would like to activate this subscr
 msgid "Plus"
 msgstr "Plus"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:128
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:138
 msgid "Practical remediation guidance"
 msgstr "Practical remediation guidance"
 
@@ -1819,7 +1826,7 @@ msgstr "Recovery codes"
 msgid "Regenerate"
 msgstr "Regenerate"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:183
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:193
 #: src/pages/panel/inventory/inventory-form/InventoryFormMore.tsx:97
 #: src/pages/panel/inventory/inventory-form/InventoryFormRegionValues.tsx:54
 #: src/pages/panel/resource-detail/ResourceDetailView.tsx:240
@@ -2149,6 +2156,10 @@ msgstr "This email address is already registered. If this is your email, please 
 msgid "This project is currently in a degraded state.<0/>Fix was unable to gather data from this project.<1/><2/>To resume security scans, please ensure that the service account you configured is set up correctly.<3/>You may also recreate and upload the service account definition."
 msgstr "This project is currently in a degraded state.<0/>Fix was unable to gather data from this project.<1/><2/>To resume security scans, please ensure that the service account you configured is set up correctly.<3/>You may also recreate and upload the service account definition."
 
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:250
+msgid "This section does not contain any controls that can be automated.<0/>Manual checks or processes are required for compliance."
+msgstr "This section does not contain any controls that can be automated.<0/>Manual checks or processes are required for compliance."
+
 #: src/pages/panel/workspace-settings-accounts/WorkspaceSettingsAccountRow.tsx:416
 msgid "This subscription is currently in a degraded state.<0/>Fix was unable to gather data from this subscription.<1/><2/>To resume security scans, please ensure that the application permissions are set up correctly.<3/>You may also recreate and redefine the access credentials."
 msgstr "This subscription is currently in a degraded state.<0/>Fix was unable to gather data from this subscription.<1/><2/>To resume security scans, please ensure that the application permissions are set up correctly.<3/>You may also recreate and redefine the access credentials."
@@ -2324,8 +2335,8 @@ msgstr "Weekly email report"
 msgid "Weekly Report"
 msgstr "Weekly Report"
 
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:102
-#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:110
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:103
+#: src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx:111
 msgid "Why does it matter"
 msgstr "Why does it matter"
 

--- a/src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkCheckCollectionDetail.tsx
@@ -1,5 +1,6 @@
 import { Trans, t } from '@lingui/macro'
 import GppGoodIcon from '@mui/icons-material/GppGood'
+import InfoIcon from '@mui/icons-material/Info'
 import { ButtonBase, Divider, Stack, Typography } from '@mui/material'
 import { DataGridPremium, GridRow, GridToolbar } from '@mui/x-data-grid-premium'
 import { useRef } from 'react'
@@ -18,9 +19,10 @@ interface BenchmarkCheckCollectionDetailProps {
   bench: BenchmarkCheckCollectionNode
   child: BenchmarkCheckCollectionNodeWithChildren[] | undefined
   onSelect: (checkId: string) => void
+  isManual: boolean
 }
 
-export const BenchmarkCheckCollectionDetail = ({ id, bench, child, onSelect }: BenchmarkCheckCollectionDetailProps) => {
+export const BenchmarkCheckCollectionDetail = ({ id, bench, child, onSelect, isManual }: BenchmarkCheckCollectionDetailProps) => {
   const page = useRef(0)
   const [pageSize, setPageSize] = usePersistState<number>(
     'BenchmarkCheckCollectionDetail.rowsPerPage',
@@ -157,6 +159,17 @@ export const BenchmarkCheckCollectionDetail = ({ id, bench, child, onSelect }: B
             rows={allFailingCheckResults}
           />
         </>
+      ) : isManual ? (
+        <Stack flex={1} justifyContent="center" alignItems="center" spacing={1} px={1} pb={2}>
+          <InfoIcon fontSize="large" color="info" sx={{ fontSize: 48 }} />
+          <Typography color="info.main" variant="h5" textAlign="center" display="inline-block">
+            <Trans>
+              This section does not contain any controls that can be automated.
+              <br />
+              Manual checks or processes are required for compliance.
+            </Trans>
+          </Typography>
+        </Stack>
       ) : (
         <Stack flex={1} justifyContent="center" alignItems="center" spacing={1}>
           <GppGoodIcon fontSize="large" color="success" sx={{ fontSize: 48 }} />

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx
@@ -1,6 +1,7 @@
 import { Trans, t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import GppGoodIcon from '@mui/icons-material/GppGood'
+import InfoIcon from '@mui/icons-material/Info'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import SearchIcon from '@mui/icons-material/Search'
 import { Button, ButtonBase, Divider, Stack, Typography } from '@mui/material'
@@ -62,7 +63,7 @@ export const BenchmarkDetailCheckDetail = ({ check, description, accountName, id
     ? panelUI.tableRowsPerPages.filter((_, i, arr) => resources.length > (arr[i - 1] ?? 0))
     : []
   return (
-    <Stack id={id} spacing={1} height={resources?.length ? 'auto' : '100%'} mb={1}>
+    <Stack id={id} spacing={1} height={resources?.length ? 'auto' : '100%'}>
       {query ? (
         <Stack justifyContent="space-between" flexWrap="wrap" gap={1} width="100%">
           <Typography variant="h4">{check.title ?? check.name}</Typography>
@@ -112,9 +113,18 @@ export const BenchmarkDetailCheckDetail = ({ check, description, accountName, id
       )}
       <Typography maxWidth={MAX_CONTAINER_WIDTH}>{check.risk}</Typography>
       <Divider flexItem />
-      <Typography variant="h5">
-        <Trans>How to fix</Trans>
-      </Typography>
+      <Stack component={Typography} variant="h5" display="flex" flexDirection="row" gap={1}>
+        <Trans>
+          How to fix
+          {detectType === 'text' ? (
+            <Typography component="span" color="info.main">
+              (<Trans>manual</Trans>)
+            </Typography>
+          ) : (
+            ''
+          )}
+        </Trans>
+      </Stack>
       <Typography maxWidth={MAX_CONTAINER_WIDTH}>{check.remediation.text}</Typography>
       {check.remediation.url ? (
         <Stack direction="row" justifyContent="end" width="100%">
@@ -129,9 +139,9 @@ export const BenchmarkDetailCheckDetail = ({ check, description, accountName, id
           </Button>
         </Stack>
       ) : null}
+      <Divider flexItem />
       {resources?.length ? (
         <>
-          <Divider flexItem />
           <Typography variant="h5">
             <Trans>Affected resources</Trans>
           </Typography>
@@ -226,15 +236,25 @@ export const BenchmarkDetailCheckDetail = ({ check, description, accountName, id
         </>
       ) : detectType !== 'text' ? (
         <>
-          <Divider flexItem />
-          <Stack flex={1} justifyContent="center" alignItems="center" spacing={1}>
+          <Stack flex={1} justifyContent="center" alignItems="center" spacing={1} pb={2}>
             <GppGoodIcon fontSize="large" color="success" sx={{ fontSize: 48 }} />
             <Typography color="success.main" variant="h5" textAlign="center">
               <Trans>All resources passed the check</Trans>
             </Typography>
           </Stack>
         </>
-      ) : null}
+      ) : (
+        <Stack flex={1} justifyContent="center" alignItems="center" spacing={1} px={1} pb={2}>
+          <InfoIcon fontSize="large" color="info" sx={{ fontSize: 48 }} />
+          <Typography color="info.main" variant="h5" textAlign="center" display="inline-block">
+            <Trans>
+              This section does not contain any controls that can be automated.
+              <br />
+              Manual checks or processes are required for compliance.
+            </Trans>
+          </Typography>
+        </Stack>
+      )}
     </Stack>
   )
 }

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx
@@ -118,7 +118,7 @@ export const BenchmarkDetailCheckDetail = ({ check, description, accountName, id
           How to fix
           {detectType === 'text' ? (
             <Typography component="span" color="info.main">
-              (<Trans>manual</Trans>)
+              ({t`manual`})
             </Typography>
           ) : (
             ''

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailCheckDetail.tsx
@@ -1,7 +1,6 @@
 import { Trans, t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import GppGoodIcon from '@mui/icons-material/GppGood'
-import InfoIcon from '@mui/icons-material/Info'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import SearchIcon from '@mui/icons-material/Search'
 import { Button, ButtonBase, Divider, Stack, Typography } from '@mui/material'
@@ -113,18 +112,9 @@ export const BenchmarkDetailCheckDetail = ({ check, description, accountName, id
       )}
       <Typography maxWidth={MAX_CONTAINER_WIDTH}>{check.risk}</Typography>
       <Divider flexItem />
-      <Stack component={Typography} variant="h5" display="flex" flexDirection="row" gap={1}>
-        <Trans>
-          How to fix
-          {detectType === 'text' ? (
-            <Typography component="span" color="info.main">
-              ({t`manual`})
-            </Typography>
-          ) : (
-            ''
-          )}
-        </Trans>
-      </Stack>
+      <Typography variant="h5">
+        <Trans>How to fix</Trans>
+      </Typography>
       <Typography maxWidth={MAX_CONTAINER_WIDTH}>{check.remediation.text}</Typography>
       {check.remediation.url ? (
         <Stack direction="row" justifyContent="end" width="100%">
@@ -243,18 +233,7 @@ export const BenchmarkDetailCheckDetail = ({ check, description, accountName, id
             </Typography>
           </Stack>
         </>
-      ) : (
-        <Stack flex={1} justifyContent="center" alignItems="center" spacing={1} px={1} pb={2}>
-          <InfoIcon fontSize="large" color="info" sx={{ fontSize: 48 }} />
-          <Typography color="info.main" variant="h5" textAlign="center" display="inline-block">
-            <Trans>
-              This section does not contain any controls that can be automated.
-              <br />
-              Manual checks or processes are required for compliance.
-            </Trans>
-          </Typography>
-        </Stack>
-      )}
+      ) : null}
     </Stack>
   )
 }

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailTree.tsx
@@ -42,12 +42,13 @@ export const BenchmarkDetailTree = () => {
           }
           workingData[item.id] =
             item.reported.kind === 'report_check_collection'
-              ? { reported: item.reported, nodeId: item.id, children: [], numberOfResourceFailing: 0 }
+              ? { reported: item.reported, nodeId: item.id, children: [], numberOfResourceFailing: 0, isManual: true }
               : {
                   reported: item.reported,
                   nodeId: item.id,
                   numberOfResourceFailing: item.reported.number_of_resources_failing ?? 0,
                   severity: item.reported.severity,
+                  isManual: !!item.reported.detect.manual,
                 }
         } else {
           benchmarkDetail = item as NodeType<{ reported: BenchmarkReportNode }> | undefined
@@ -68,6 +69,9 @@ export const BenchmarkDetailTree = () => {
             (!from.severity || sortedSeverities.indexOf(to.severity) < sortedSeverities.indexOf(from.severity))
           ) {
             from.severity = to.severity
+          }
+          if (!to.isManual) {
+            from.isManual = false
           }
           to.parent = from
         }

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx
@@ -1,3 +1,5 @@
+import { t } from '@lingui/macro'
+import InfoIcon from '@mui/icons-material/Info'
 import { Stack, Typography } from '@mui/material'
 import { TreeItem } from '@mui/x-tree-view'
 import { getColorBySeverity, getIconBySeverity } from 'src/pages/panel/shared/utils'
@@ -13,6 +15,7 @@ export interface BenchmarkCheckCollectionNodeWithChildren {
   reported: BenchmarkCheckCollectionNode | BenchmarkCheckResultNode
   severity?: SeverityType
   numberOfResourceFailing: number
+  isManual: boolean
 }
 
 export interface BenchmarkDetailTreeItemProps {
@@ -21,14 +24,14 @@ export interface BenchmarkDetailTreeItemProps {
 
 const BenchmarkDetailTreeItemLabel = ({ item }: BenchmarkDetailTreeItemProps) => {
   const severity = item.numberOfResourceFailing && item.severity ? item.severity : 'passed'
-  const color = getColorBySeverity(severity)
-  const Comp = getIconBySeverity(severity)
+  const color = item.isManual ? 'grey.500' : getColorBySeverity(severity)
+  const Comp = item.isManual ? InfoIcon : getIconBySeverity(severity)
   return (
     <Stack direction="row" gap={1} justifyContent="space-between" alignItems="center" fontWeight={600} id={`item-${item.nodeId}`}>
       {item.reported.name}
       <Stack direction="row" justifyContent="end" flexGrow={1} flexShrink={0} spacing={1} alignItems="center">
         <Typography color={color} variant="caption" fontWeight={700}>
-          {getMessage(snakeCaseToUFStr(severity))}
+          {item.isManual ? t`Manual` : getMessage(snakeCaseToUFStr(severity))}
         </Typography>
         <Comp fontSize="small" sx={{ color }} />
       </Stack>

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailTreeItem.tsx
@@ -20,14 +20,28 @@ export interface BenchmarkCheckCollectionNodeWithChildren {
 
 export interface BenchmarkDetailTreeItemProps {
   item: BenchmarkCheckCollectionNodeWithChildren
+  withDot?: boolean
 }
 
-const BenchmarkDetailTreeItemLabel = ({ item }: BenchmarkDetailTreeItemProps) => {
+const BenchmarkDetailTreeItemLabel = ({ item, withDot }: BenchmarkDetailTreeItemProps) => {
   const severity = item.numberOfResourceFailing && item.severity ? item.severity : 'passed'
   const color = item.isManual ? 'grey.500' : getColorBySeverity(severity)
   const Comp = item.isManual ? InfoIcon : getIconBySeverity(severity)
   return (
-    <Stack direction="row" gap={1} justifyContent="space-between" alignItems="center" fontWeight={600} id={`item-${item.nodeId}`}>
+    <Stack
+      direction="row"
+      gap={1}
+      justifyContent="space-between"
+      alignItems="center"
+      fontWeight={600}
+      id={`item-${item.nodeId}`}
+      position="relative"
+    >
+      {withDot ? (
+        <Stack position="absolute" left={-20} color="primary.main">
+          •
+        </Stack>
+      ) : null}
       {item.reported.name}
       <Stack direction="row" justifyContent="end" flexGrow={1} flexShrink={0} spacing={1} alignItems="center">
         <Typography color={color} variant="caption" fontWeight={700}>
@@ -46,7 +60,7 @@ export const BenchmarkDetailTreeItem = ({ item }: BenchmarkDetailTreeItemProps) 
         child.reported.kind === 'report_check_collection' ? (
           <BenchmarkDetailTreeItem key={child.nodeId} item={child} />
         ) : (
-          <TreeItem key={child.nodeId} itemId={child.nodeId} label={<BenchmarkDetailTreeItemLabel item={child} />} sx={{ py: 1 }} />
+          <TreeItem key={child.nodeId} itemId={child.nodeId} label={<BenchmarkDetailTreeItemLabel item={child} withDot />} sx={{ py: 1 }} />
         ),
       )}
     </TreeItem>

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailTreeWithDetail.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailTreeWithDetail.tsx
@@ -172,11 +172,11 @@ export const BenchmarkDetailTreeWithDetail = ({
           key={0}
           expandedItems={expandedItems}
           selectedItems={selectedId}
-          slots={{
-            // expandIcon: FiberManualRecordIcon,
-            // collapseIcon: FiberManualRecordOutlinedIcon,
-            endIcon: () => '•',
-          }}
+          // slots={{
+          //   // expandIcon: FiberManualRecordIcon,
+          //   // collapseIcon: FiberManualRecordOutlinedIcon,
+          //   endIcon: () => '•',
+          // }}
           sx={{
             [`& .${treeItemClasses.iconContainer}`]: ({
               palette: {

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailTreeWithDetail.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailTreeWithDetail.tsx
@@ -201,6 +201,7 @@ export const BenchmarkDetailTreeWithDetail = ({
               bench={currentData.reported}
               child={currentData.children}
               onSelect={handleManualSelect}
+              isManual={currentData.isManual}
             />
           ) : (
             <BenchmarkDetailCheckDetail

--- a/src/pages/panel/benchmark-detail/BenchmarkDetailTreeWithDetail.tsx
+++ b/src/pages/panel/benchmark-detail/BenchmarkDetailTreeWithDetail.tsx
@@ -1,5 +1,5 @@
 import { SimpleTreeView, treeItemClasses } from '@mui/x-tree-view'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useAbsoluteNavigate } from 'src/shared/absolute-navigate'
 import { BenchmarkReportNode } from 'src/shared/types/server'
@@ -34,6 +34,7 @@ export const BenchmarkDetailTreeWithDetail = ({
   const params = useSearchParams()[0]
   const expandedItems = params.get('expanded-items')?.split(',') ?? []
   const selectedId = params.get('selected-id')
+  const previousSelected = useRef(selectedId)
   const oneParentId = dataWithChildren.length === 1 ? dataWithChildren[0].nodeId : undefined
 
   const navigateWithQueryParams = useCallback(
@@ -125,12 +126,13 @@ export const BenchmarkDetailTreeWithDetail = ({
         let pathname = `/benchmark/${benchmarkId}${accountId ? `/${accountId}` : ''}`
         const foundExpandedItemIndex = expandedItems.indexOf(itemId)
         if (!oneParentId || expandedItems[foundExpandedItemIndex] !== oneParentId) {
-          if (foundExpandedItemIndex > -1) {
+          if (foundExpandedItemIndex > -1 && previousSelected.current === itemId) {
             expandedItems.splice(foundExpandedItemIndex, 1)
           } else {
             expandedItems.push(itemId)
           }
         }
+        previousSelected.current = itemId
         const item = allData[itemId]
         if (item) {
           if (item.reported.kind === 'report_check_result') {


### PR DESCRIPTION
# Description
#### Issue No: 753
add manual info section into benchmark detail
![image](https://github.com/someengineering/fixfrontend/assets/2679112/49e16b61-22de-47fd-b3ce-95b411ddb2a7)
![image](https://github.com/someengineering/fixfrontend/assets/2679112/62e468a1-4927-43c2-a3f3-9baa77bbd1c7)

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
