### PR TITLE
[fix] when get an error from benchmarks API assume no benchmarks are available

### DIFF
--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -862,7 +862,7 @@ msgstr "Kritisch"
 msgid "Current Product Tier"
 msgstr ""
 
-#: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:305
+#: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:306
 msgid "Currently, there are no connected services available for configuration. Please be informed that connecting at least one service is necessary to configure alerting settings."
 msgstr "Derzeit stehen keine verbundenen Dienste zur Konfiguration zur Verfügung. Bitte beachten Sie, dass zum Konfigurieren der Alarmeinstellungen die Verbindung mindestens eines Dienstes erforderlich ist."
 
@@ -2448,6 +2448,10 @@ msgstr ""
 #: src/pages/panel/inventory/DownloadCSVButton.tsx:90
 msgid "Warning"
 msgstr "Warnung"
+
+#: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:311
+msgid "We are currently trying to list your projects. Please stay tuned - we will send you an Email when cloud accounts have been collected"
+msgstr ""
 
 #: src/pages/auth/login/LoginPage.tsx:191
 msgid "We have sent an email with a confirmation link to your email address. Please follow the link to activate your account."

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -862,7 +862,7 @@ msgstr "Critical"
 msgid "Current Product Tier"
 msgstr "Current Product Tier"
 
-#: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:305
+#: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:306
 msgid "Currently, there are no connected services available for configuration. Please be informed that connecting at least one service is necessary to configure alerting settings."
 msgstr "Currently, there are no connected services available for configuration. Please be informed that connecting at least one service is necessary to configure alerting settings."
 
@@ -2448,6 +2448,10 @@ msgstr "Version"
 #: src/pages/panel/inventory/DownloadCSVButton.tsx:90
 msgid "Warning"
 msgstr "Warning"
+
+#: src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx:311
+msgid "We are currently trying to list your projects. Please stay tuned - we will send you an Email when cloud accounts have been collected"
+msgstr "We are currently trying to list your projects. Please stay tuned - we will send you an Email when cloud accounts have been collected"
 
 #: src/pages/auth/login/LoginPage.tsx:191
 msgid "We have sent an email with a confirmation link to your email address. Please follow the link to activate your account."

--- a/src/pages/panel/shared/queries/getWorkspaceInventoryReportBenchmarks.query.ts
+++ b/src/pages/panel/shared/queries/getWorkspaceInventoryReportBenchmarks.query.ts
@@ -6,12 +6,13 @@ import { axiosWithAuth } from 'src/shared/utils/axios'
 
 export const getWorkspaceInventoryReportBenchmarksQuery = ({
   signal,
-  queryKey: [, workspaceId, benchmark_ids, short, with_checks, ids_only],
+  queryKey: [, workspaceId, benchmark_ids, short, with_checks, ids_only, withError0Result],
 }: QueryFunctionContext<
   [
     'workspace-inventory-report-benchmarks',
     string | undefined,
     string | undefined,
+    boolean | undefined,
     boolean | undefined,
     boolean | undefined,
     boolean | undefined,
@@ -37,5 +38,11 @@ export const getWorkspaceInventoryReportBenchmarksQuery = ({
           params: Object.keys(params).length ? params : undefined,
         })
         .then((res) => res.data)
+        .catch((e) => {
+          if (withError0Result) {
+            return [] as Benchmark[]
+          }
+          throw e
+        })
     : ([] as Benchmark[])
 }

--- a/src/pages/panel/shared/utils/useGetBenchmarks.ts
+++ b/src/pages/panel/shared/utils/useGetBenchmarks.ts
@@ -4,15 +4,28 @@ import { useUserProfile } from 'src/core/auth'
 import { getWorkspaceInventoryReportBenchmarksQuery } from 'src/pages/panel/shared/queries'
 import { Benchmark } from 'src/shared/types/server-shared'
 
-export function useGetBenchmarks(select: true, ids?: string[] | undefined): { data: Benchmark[] | undefined; isLoading: boolean }
+export function useGetBenchmarks(
+  select: true,
+  ids?: string[] | undefined,
+  withError0Result?: boolean,
+): { data: Benchmark[] | undefined; isLoading: boolean }
 export function useGetBenchmarks(
   select?: false,
   ids?: string[],
+  withError0Result?: boolean,
 ): { data: Record<string, Benchmark | undefined> | undefined; isLoading: boolean }
-export function useGetBenchmarks(select: boolean = false, ids: string[] = []) {
+export function useGetBenchmarks(select: boolean = false, ids: string[] = [], withError0Result?: boolean) {
   const { selectedWorkspace } = useUserProfile()
   const { data, isLoading } = useQuery({
-    queryKey: ['workspace-inventory-report-benchmarks', selectedWorkspace?.id, select ? ids.join(',') : undefined, true, false, false],
+    queryKey: [
+      'workspace-inventory-report-benchmarks',
+      selectedWorkspace?.id,
+      select ? ids.join(',') : undefined,
+      true,
+      false,
+      false,
+      withError0Result,
+    ],
     queryFn: getWorkspaceInventoryReportBenchmarksQuery,
     gcTime: Number.POSITIVE_INFINITY,
   })

--- a/src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx
+++ b/src/pages/panel/workspace-settings/workspace-alerting-settings/WorkspaceAlertingSettings.tsx
@@ -69,7 +69,7 @@ const WorkspaceAlertingSettingsCheckbox = ({
 export const WorkspaceAlertingSettings = () => {
   const { selectedWorkspace, checkPermission } = useUserProfile()
   const hasPermission = checkPermission('updateSettings')
-  const { data: benchmarks, isLoading: isBenchmarksLoading } = useGetBenchmarks(true)
+  const { data: benchmarks, isLoading: isBenchmarksLoading } = useGetBenchmarks(true, undefined, true)
   const [{ data: alertingSettings, isLoading: isAlertingSettingsLoading }, { data: notifications, isLoading: isNotificationsLoading }] =
     useQueries({
       queries: [
@@ -301,11 +301,18 @@ export const WorkspaceAlertingSettings = () => {
     </TableContainer>
   ) : (
     <Stack>
-      <Alert severity="warning">
-        <Trans>
-          Currently, there are no connected services available for configuration. Please be informed that connecting at least one service is
-          necessary to configure alerting settings.
-        </Trans>
+      <Alert severity={benchmarks?.length ? 'warning' : 'info'}>
+        {benchmarks?.length ? (
+          <Trans>
+            Currently, there are no connected services available for configuration. Please be informed that connecting at least one service
+            is necessary to configure alerting settings.
+          </Trans>
+        ) : (
+          <Trans>
+            We are currently trying to list your projects. Please stay tuned - we will send you an Email when cloud accounts have been
+            collected
+          </Trans>
+        )}
       </Alert>
     </Stack>
   )


### PR DESCRIPTION
# Description
#### Issue No: 779
when get an error from benchmarks API assume no benchmarks are available

# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
