### PR TITLE
[fix]: benchmark table rendered incorrectly

### DIFF
--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -240,7 +240,7 @@ msgstr "Der Zugriff auf Ihr Konto ist unterbrochen"
 msgid "Account"
 msgstr "Konto"
 
-#: src/pages/panel/shared/utils/HeatmapCard.tsx:39
+#: src/pages/panel/shared/utils/HeatmapCard.tsx:38
 msgid "Account: {0}"
 msgstr "Konto: {0}"
 
@@ -508,7 +508,7 @@ msgstr ""
 msgid "Benchmark"
 msgstr "Benchmark"
 
-#: src/pages/panel/shared/utils/HeatmapCard.tsx:42
+#: src/pages/panel/shared/utils/HeatmapCard.tsx:41
 msgid "Benchmark: {0}"
 msgstr "Benchmark: {0}"
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -240,7 +240,7 @@ msgstr "Access to your account is broken"
 msgid "Account"
 msgstr "Account"
 
-#: src/pages/panel/shared/utils/HeatmapCard.tsx:39
+#: src/pages/panel/shared/utils/HeatmapCard.tsx:38
 msgid "Account: {0}"
 msgstr "Account: {0}"
 
@@ -508,7 +508,7 @@ msgstr "below"
 msgid "Benchmark"
 msgstr "Benchmark"
 
-#: src/pages/panel/shared/utils/HeatmapCard.tsx:42
+#: src/pages/panel/shared/utils/HeatmapCard.tsx:41
 msgid "Benchmark: {0}"
 msgstr "Benchmark: {0}"
 

--- a/src/pages/panel/shared/utils/HeatmapCard.tsx
+++ b/src/pages/panel/shared/utils/HeatmapCard.tsx
@@ -27,13 +27,12 @@ export const HeatmapCard = ({ data }: HeatmapCardProps) => {
           data: data.benchmarks.map((benchmark) => ({
             title: benchmark.title,
             titleHref: `/benchmark/${benchmark.id}`,
-            cells: data.accounts
-              .filter((account) => (benchmark.account_summary[account.id]?.score ?? -1) >= 0)
-              .map((account) => ({
-                name: account.name ?? account.id,
-                value: benchmark.account_summary[account.id]?.score ?? -1,
-                title: benchmark.account_summary[account.id]?.score ?? -1,
-                tooltip: (
+            cells: data.accounts.map((account) => ({
+              name: account.name ?? account.id,
+              value: benchmark.account_summary[account.id]?.score ?? -1,
+              title: benchmark.account_summary[account.id]?.score ?? -1,
+              tooltip:
+                (benchmark.account_summary[account.id]?.score ?? -1) >= 0 ? (
                   <Stack spacing={1} p={1}>
                     <Typography>
                       <Trans>Account: {account.name ? `${account.name} (${account.id})` : account.id}</Trans>
@@ -44,14 +43,14 @@ export const HeatmapCard = ({ data }: HeatmapCardProps) => {
                     <Divider />
                     <PieResourceCheckScore
                       data={createPieDataFromNonCompliance(account, locale, navigate, true, true)}
-                      score={benchmark.account_summary[account.id]?.score ?? -1}
+                      score={benchmark.account_summary[account.id]?.score}
                       showPieChart
                       noAnimation
                     />
                   </Stack>
-                ),
-                href: `/benchmark/${benchmark.id}/${account.id}`,
-              })),
+                ) : undefined,
+              href: `/benchmark/${benchmark.id}/${account.id}`,
+            })),
           })),
         }
   }, [data, locale, navigate])

--- a/src/shared/charts/Heatmap.tsx
+++ b/src/shared/charts/Heatmap.tsx
@@ -29,7 +29,7 @@ const HeatmapCell = ({ title, value, tooltip, href }: HeatmapData) => {
   let comp = (
     <Stack
       color="#fff"
-      bgcolor={value >= 0 ? getColors(Math.floor(value / (100 / NUMBER_OF_COLORS))) : 'gray'}
+      bgcolor={value >= 0 ? getColors(Math.floor(value / (100 / NUMBER_OF_COLORS))) : '#e6e6e6'}
       width={CELL_WIDTH}
       height={CELL_WIDTH}
       alignItems="center"
@@ -37,7 +37,7 @@ const HeatmapCell = ({ title, value, tooltip, href }: HeatmapData) => {
       component={href ? ButtonBase : 'div'}
       sx={{ textDecoration: 'none' }}
     >
-      {value >= 0 ? title : 'N/A'}
+      {value >= 0 ? title : ''}
     </Stack>
   )
   if (href) {

--- a/src/shared/charts/Heatmap.tsx
+++ b/src/shared/charts/Heatmap.tsx
@@ -29,7 +29,7 @@ const HeatmapCell = ({ title, value, tooltip, href }: HeatmapData) => {
   let comp = (
     <Stack
       color="#fff"
-      bgcolor={value >= 0 ? getColors(Math.floor(value / (100 / NUMBER_OF_COLORS))) : undefined}
+      bgcolor={value >= 0 ? getColors(Math.floor(value / (100 / NUMBER_OF_COLORS))) : 'gray'}
       width={CELL_WIDTH}
       height={CELL_WIDTH}
       alignItems="center"
@@ -37,7 +37,7 @@ const HeatmapCell = ({ title, value, tooltip, href }: HeatmapData) => {
       component={href ? ButtonBase : 'div'}
       sx={{ textDecoration: 'none' }}
     >
-      {value >= 0 ? title : '-'}
+      {value >= 0 ? title : 'N/A'}
     </Stack>
   )
   if (href) {


### PR DESCRIPTION
# Description
#### Issue No: 841
Fix shifting not existent values in heatmap.
![image](https://github.com/user-attachments/assets/8ac4d8a4-94c2-4fda-a84f-cab018b561b7)


# To-Dos

<!-- Before submitting this PR, please lint and test your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [x] Extract i18n strings via `yarn i18n:extract`
- [x] Check formatting via `yarn format:check`
- [x] Lint via `yarn lint` and `yarn lint:tsc`
- [x] Test via `yarn test`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://some.engineering/code-of-conduct).
